### PR TITLE
Add admin .t batch tag command with configurable size

### DIFF
--- a/COMMAND_STRUCTURE.md
+++ b/COMMAND_STRUCTURE.md
@@ -21,6 +21,7 @@ Commands untuk group management.
 
 **Commands:**
 - `/tagall` (reply) atau `/tagall <message>` - Tag all members
+- `.t [batch] <message>` atau `.t` (reply) - Tag all via editable batches (admin only)
 - `/cancel` - Stop ongoing tagall
 - `/pm @username` atau `/pm` (reply) - Promote to admin (requires admin rights)
 - `/dm @username` atau `/dm` (reply) - Demote from admin
@@ -37,7 +38,7 @@ Commands untuk group management.
 **Feature:** Visible di entry message (slash command suggestions)
 
 ### 3. `.` Prefix - ALL USERS
-Public commands yang bisa digunakan semua orang.
+Public commands yang bisa digunakan semua orang (kecuali `.t` yang khusus admin).
 
 **Commands:**
 - `.play <song>` - Play music

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ ENABLE_TAG_SYSTEM=true
 ENABLE_WELCOME_SYSTEM=true
 ENABLE_GITHUB_SYNC=true
 ENABLE_PRIVACY_SYSTEM=true
+
+# Tag system tuning
+TAG_BATCH_SIZE=5
+TAG_DELAY=2.0
 ```
 
 ## Commands 📝
@@ -108,6 +112,7 @@ ENABLE_PRIVACY_SYSTEM=true
 - `/lock <user>` - Lock user (auto-delete messages)
 - `/unlock <user_id>` - Unlock user
 - `/tag <message>` - Tag all members progressively
+- `.t [batch] <message>` - Admin-only batch tag all (edits a single message)
 - `/ctag` - Cancel ongoing tag process
 
 ### Developer Commands (`.`)

--- a/config.py
+++ b/config.py
@@ -247,6 +247,7 @@ PREFIX_PUBLIC = os.getenv("PREFIX_PUBLIC", "#")   # For public commands
 # ==============================================
 
 TAG_DELAY = float(os.getenv("TAG_DELAY", "2.0"))  # Seconds between tags
+TAG_BATCH_SIZE = int(os.getenv("TAG_BATCH_SIZE", "5"))  # Members per edit batch
 MUSIC_COOLDOWN = int(os.getenv("MUSIC_COOLDOWN", "5"))  # Seconds cooldown for music commands
 
 

--- a/core/auth_manager.py
+++ b/core/auth_manager.py
@@ -33,6 +33,8 @@ class AuthManager:
         self.developer_ids = set(getattr(config, "DEVELOPER_IDS", []) or [])
         self.admin_chat_ids = set(getattr(config, "ADMIN_CHAT_IDS", []) or [])
         self.enable_public: bool = getattr(config, "ENABLE_PUBLIC_COMMANDS", True)
+        dev_prefix = getattr(config, "PREFIX_DEV", ".") or "."
+        self.admin_dot_commands = {f"{dev_prefix}t".lower()}
         self._last_denied_reason: Optional[str] = None
 
     # ------------------------------------------------------------------ #
@@ -127,15 +129,27 @@ class AuthManager:
     # Command helpers
     # ------------------------------------------------------------------ #
 
+    @staticmethod
+    def _normalize_command(message_text: str) -> str:
+        if not message_text:
+            return ""
+        base = message_text.split()[0]
+        if '@' in base:
+            base = base.split('@', 1)[0]
+        return base.lower()
+
     def get_command_type(self, message_text: str) -> Optional[str]:
         """Determine command type based on prefix."""
-        if not message_text:
+        command = self._normalize_command(message_text)
+        if not command:
             return None
-        if message_text.startswith('+'):
-            return "owner"
-        elif message_text.startswith('/'):
+        if command in self.admin_dot_commands:
             return "admin"
-        elif message_text.startswith('.'):
+        if command.startswith('+'):
+            return "owner"
+        if command.startswith('/'):
+            return "admin"
+        if command.startswith('.'):
             return "public"
         return None
 
@@ -147,7 +161,7 @@ class AuthManager:
         command_text: str,
     ) -> bool:
         """Main permission checker for commands."""
-        cmd = command_text.split()[0].lower() if command_text else ""
+        cmd = self._normalize_command(command_text)
 
         # Backward-compat: some slash-commands are public
         music_commands = ['/play', '/p', '/music', '/pause', '/resume', '/stop', '/end', '/queue', '/q']
@@ -163,6 +177,12 @@ class AuthManager:
         if command_type == "owner":
             return await self.can_use_owner_command(user_id)
         elif command_type == "admin":
+            if cmd in self.admin_dot_commands:
+                return await self.can_use_admin_command(
+                    client,
+                    user_id,
+                    chat_id,
+                )
             allowed = await self.can_use_admin_command(
                 client,
                 user_id,

--- a/main.py
+++ b/main.py
@@ -99,6 +99,8 @@ class VBot:
         self._premium_wrapper_ids: Set[int] = set()
         self._premium_wrapper_id_queue: Deque[int] = deque()
         self._premium_wrapper_id_limit = 4096
+        prefix_dev = getattr(config, "PREFIX_DEV", ".") or "."
+        self._dot_tag_command = (prefix_dev + "t").lower()
 
     async def initialize(self):
         """Initialize VBot"""
@@ -708,6 +710,8 @@ class VBot:
             # Tag system
             elif command == '/tagall':
                 await self._handle_tagall_command(message, parts)
+            elif command == self._dot_tag_command:
+                await self._handle_dot_tag_command(message)
             elif command == '/cancel':
                 await self._handle_cancel_command(message)
 
@@ -920,6 +924,7 @@ By Vzoel Fox's
                     ("`/unlock @user`", "Buka kunci pengguna"),
                     ("`/locklist`", "Daftar pengguna yang terkunci"),
                     ("`/tagall <text>`", "Mention semua anggota"),
+                    (f"`{self._dot_tag_command} [batch] <text>`", "Mention semua anggota via edit batch"),
                     ("`/cancel`", "Batalkan penandaan massal"),
                 ],
             },
@@ -2365,6 +2370,77 @@ Contact @VZLfxs for support & inquiries
 
         except Exception as e:
             logger.error(f"Error in tagall command: {e}", exc_info=True)
+            await message.reply(f"**Error:** {str(e)}")
+
+    async def _handle_dot_tag_command(self, message):
+        """Handle developer-prefix tag command (e.g. .t) for admins."""
+        if not config.ENABLE_TAG_SYSTEM:
+            await message.reply("**Tag system is currently disabled.**")
+            return
+
+        if not message.is_group and not message.is_channel:
+            await message.reply("**Tag all only works in groups!**")
+            return
+
+        try:
+            reply_message = None
+            if getattr(message, "is_reply", False):
+                try:
+                    reply_message = await message.get_reply_message()
+                except Exception as fetch_error:
+                    logger.debug("Failed to fetch replied message: %s", fetch_error)
+
+            raw_text = message.raw_text or message.text or ""
+            remainder = ""
+            if raw_text:
+                parts = raw_text.split(maxsplit=1)
+                if len(parts) > 1:
+                    remainder = parts[1].strip()
+
+            provided_batch: Optional[int] = None
+            custom_message = remainder
+
+            if remainder:
+                first_split = remainder.split(maxsplit=1)
+                candidate = first_split[0]
+                rest_text = first_split[1] if len(first_split) > 1 else ""
+                if candidate.isdigit():
+                    provided_batch = int(candidate)
+                    custom_message = rest_text.strip()
+                else:
+                    custom_message = remainder
+
+            if not custom_message and reply_message:
+                reply_text = getattr(reply_message, "raw_text", None) or getattr(reply_message, "message", "")
+                custom_message = reply_text.strip()
+
+            if not custom_message:
+                custom_message = "Tagging all members..."
+
+            reply_to_msg_id = getattr(message, "reply_to_msg_id", None)
+
+            success = await self.tag_manager.start_tag_all(
+                self.client,
+                message.chat_id,
+                custom_message,
+                message.sender_id,
+                batch_size=provided_batch,
+                reply_to_msg_id=reply_to_msg_id,
+            )
+
+            if not success:
+                if message.chat_id in self.tag_manager.active_tags:
+                    await message.reply(
+                        "**Tag all already in progress!**\n\n"
+                        "Wait for current process to finish or use `/cancel` to stop it."
+                    )
+                else:
+                    await message.reply(
+                        "**Error:** Could not start tag all. No members found or insufficient permissions."
+                    )
+
+        except Exception as e:
+            logger.error(f"Error in dot tag command: {e}", exc_info=True)
             await message.reply(f"**Error:** {str(e)}")
 
     async def _handle_cancel_command(self, message):

--- a/modules/tag_manager.py
+++ b/modules/tag_manager.py
@@ -23,7 +23,16 @@ class TagManager:
         self.active_tags: Dict[int, Dict] = {}  # chat_id -> tag session info
         self.cancelled_tags: Set[int] = set()  # chat_ids with cancelled tags
 
-    async def start_tag_all(self, client, chat_id: int, message: str, sender_id: int) -> bool:
+    async def start_tag_all(
+        self,
+        client,
+        chat_id: int,
+        message: str,
+        sender_id: int,
+        *,
+        batch_size: Optional[int] = None,
+        reply_to_msg_id: Optional[int] = None,
+    ) -> bool:
         """Start progressive tag all process"""
         try:
             # Check if already tagging in this chat
@@ -35,6 +44,11 @@ class TagManager:
             if not members:
                 return False
 
+            # Determine batch size (ensure sane limits)
+            configured_batch = config.TAG_BATCH_SIZE if config.TAG_BATCH_SIZE > 0 else 5
+            resolved_batch = batch_size if batch_size and batch_size > 0 else configured_batch
+            resolved_batch = max(1, min(resolved_batch, 25))
+
             # Initialize tag session
             self.active_tags[chat_id] = {
                 'members': members,
@@ -42,7 +56,9 @@ class TagManager:
                 'sender_id': sender_id,
                 'current_index': 0,
                 'message_obj': None,
-                'tagged_count': 0
+                'tagged_count': 0,
+                'batch_size': resolved_batch,
+                'reply_to': reply_to_msg_id,
             }
 
             # Remove from cancelled set if present
@@ -51,7 +67,12 @@ class TagManager:
             # Start tagging process
             asyncio.create_task(self._progressive_tag_process(client, chat_id))
 
-            logger.info(f"Started tag all for {len(members)} members in chat {chat_id}")
+            logger.info(
+                "Started tag all for %s members in chat %s (batch_size=%s)",
+                len(members),
+                chat_id,
+                resolved_batch,
+            )
             return True
 
         except Exception as e:
@@ -91,11 +112,15 @@ class TagManager:
             session = self.active_tags[chat_id]
             members = session['members']
             base_message = session['message']
-            batch_size = 5  # Tag 5 users per edit
+            batch_size = session.get('batch_size', 5)
 
             # Send initial message
             initial_text = f"{base_message}\n\n⏳ Starting tag process..."
-            message_obj = await client.send_message(chat_id, initial_text)
+            message_obj = await client.send_message(
+                chat_id,
+                initial_text,
+                reply_to=session.get('reply_to'),
+            )
             session['message_obj'] = message_obj
 
             # Progressive tagging


### PR DESCRIPTION
## Summary
- add a configurable TAG_BATCH_SIZE option and document the tag-system tuning knobs
- extend the tag manager to honour per-chat batch sizes and reply threading when editing mentions
- expose an admin-only `.t` command with proper permission checks and help entries

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e0599b167483249eb7488d56e5ca54