### PR TITLE
Align tag workflows with new /t and /c command aliases

### DIFF
--- a/COMMAND_STRUCTURE.md
+++ b/COMMAND_STRUCTURE.md
@@ -20,8 +20,8 @@ Commands untuk management bot dan user permissions.
 Commands untuk group management.
 
 **Commands:**
-- `/tagall` (reply) atau `/tagall <message>` - Tag all members
-- `/cancel` - Stop ongoing tagall
+- `/t [batch] <message>` atau `/t` (reply) - Tag semua anggota via edit batch (alias: `.t`, `+t`)
+- `/c` - Hentikan proses tag massal (alias: `.c`, `+c`)
 - `/pm @username` atau `/pm` (reply) - Promote to admin (requires admin rights)
 - `/dm @username` atau `/dm` (reply) - Demote from admin
 - `/lock @username` atau `/lock` (reply) - Auto-delete user messages
@@ -37,15 +37,15 @@ Commands untuk group management.
 **Feature:** Visible di entry message (slash command suggestions)
 
 ### 3. `.` Prefix - ALL USERS
-Public commands yang bisa digunakan semua orang.
+Public commands yang bisa digunakan semua orang (kecuali `.t` yang khusus admin).
 
-**Commands:**
 - `.play <song>` - Play music
 - `.pause` - Pause music
 - `.resume` - Resume music
 - `.stop` - Stop music
 - `.queue` - Show queue
 - `.gensession` - Generate session string (PM only)
+- `.t [batch] <message>` atau `.t` (reply) - Alias admin untuk `/t`
 
 **Permission:** Semua user
 
@@ -96,7 +96,7 @@ Public commands yang bisa digunakan semua orang.
 - [x] Implement `+add` and `+del` commands
 - [x] Implement `/pm` and `/dm` commands
 - [x] Implement `+setwelcome` command
-- [x] Implement `/cancel` command
+- [x] Implement `/c` command (alias `.c` / `+c`)
 - [x] Implement `/locklist` command
 - [x] Update `/lock` to use database (migrated to Database)
 - [x] Update welcome system to use database (migrated to Database)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ ENABLE_TAG_SYSTEM=true
 ENABLE_WELCOME_SYSTEM=true
 ENABLE_GITHUB_SYNC=true
 ENABLE_PRIVACY_SYSTEM=true
+
+# Tag system tuning
+TAG_BATCH_SIZE=5
+TAG_DELAY=2.0
 ```
 
 ## Commands 📝
@@ -107,14 +111,15 @@ ENABLE_PRIVACY_SYSTEM=true
 - `/play <song>` - Play music from YouTube
 - `/lock <user>` - Lock user (auto-delete messages)
 - `/unlock <user_id>` - Unlock user
-- `/tag <message>` - Tag all members progressively
-- `/ctag` - Cancel ongoing tag process
+- `/t [batch] <message>` atau `/t` (reply) - Tag semua anggota secara bertahap (alias: `.t`, `+t`)
+- `/c` - Hentikan proses tag massal (alias: `.c`, `+c`)
 
 ### Developer Commands (`.`)
 - `.stats` - Show bot statistics
 - `.setwelcome <message>` - Set welcome message
 - `.welcome on/off` - Toggle welcome system
 - `.privacy` - Toggle privacy mode
+- `.t [batch] <message>` atau `.t` (reply) - Alias admin untuk `/t`
 
 ### Public Commands (`#`)
 - `#help` - Show help message

--- a/config.py
+++ b/config.py
@@ -247,6 +247,7 @@ PREFIX_PUBLIC = os.getenv("PREFIX_PUBLIC", "#")   # For public commands
 # ==============================================
 
 TAG_DELAY = float(os.getenv("TAG_DELAY", "2.0"))  # Seconds between tags
+TAG_BATCH_SIZE = int(os.getenv("TAG_BATCH_SIZE", "5"))  # Members per edit batch
 MUSIC_COOLDOWN = int(os.getenv("MUSIC_COOLDOWN", "5"))  # Seconds cooldown for music commands
 
 

--- a/core/auth_manager.py
+++ b/core/auth_manager.py
@@ -33,6 +33,12 @@ class AuthManager:
         self.developer_ids = set(getattr(config, "DEVELOPER_IDS", []) or [])
         self.admin_chat_ids = set(getattr(config, "ADMIN_CHAT_IDS", []) or [])
         self.enable_public: bool = getattr(config, "ENABLE_PUBLIC_COMMANDS", True)
+        self._tag_command_prefixes = (".", "/", "+")
+        self._admin_tag_commands = {f"{prefix}t" for prefix in self._tag_command_prefixes}
+        self._admin_tag_cancel_commands = {f"{prefix}c" for prefix in self._tag_command_prefixes}
+        self._admin_override_commands = (
+            self._admin_tag_commands | self._admin_tag_cancel_commands
+        )
         self._last_denied_reason: Optional[str] = None
 
     # ------------------------------------------------------------------ #
@@ -127,15 +133,27 @@ class AuthManager:
     # Command helpers
     # ------------------------------------------------------------------ #
 
+    @staticmethod
+    def _normalize_command(message_text: str) -> str:
+        if not message_text:
+            return ""
+        base = message_text.split()[0]
+        if '@' in base:
+            base = base.split('@', 1)[0]
+        return base.lower()
+
     def get_command_type(self, message_text: str) -> Optional[str]:
         """Determine command type based on prefix."""
-        if not message_text:
+        command = self._normalize_command(message_text)
+        if not command:
             return None
-        if message_text.startswith('+'):
-            return "owner"
-        elif message_text.startswith('/'):
+        if command in self._admin_override_commands:
             return "admin"
-        elif message_text.startswith('.'):
+        if command.startswith('+'):
+            return "owner"
+        if command.startswith('/'):
+            return "admin"
+        if command.startswith('.'):
             return "public"
         return None
 
@@ -147,7 +165,7 @@ class AuthManager:
         command_text: str,
     ) -> bool:
         """Main permission checker for commands."""
-        cmd = command_text.split()[0].lower() if command_text else ""
+        cmd = self._normalize_command(command_text)
 
         # Backward-compat: some slash-commands are public
         music_commands = ['/play', '/p', '/music', '/pause', '/resume', '/stop', '/end', '/queue', '/q']
@@ -163,6 +181,12 @@ class AuthManager:
         if command_type == "owner":
             return await self.can_use_owner_command(user_id)
         elif command_type == "admin":
+            if cmd in self._admin_override_commands:
+                return await self.can_use_admin_command(
+                    client,
+                    user_id,
+                    chat_id,
+                )
             allowed = await self.can_use_admin_command(
                 client,
                 user_id,

--- a/main.py
+++ b/main.py
@@ -99,6 +99,9 @@ class VBot:
         self._premium_wrapper_ids: Set[int] = set()
         self._premium_wrapper_id_queue: Deque[int] = deque()
         self._premium_wrapper_id_limit = 4096
+        self._tag_prefixes = (".", "/", "+")
+        self._tag_start_commands = {f"{prefix}t" for prefix in self._tag_prefixes}
+        self._tag_stop_commands = {f"{prefix}c" for prefix in self._tag_prefixes}
 
     async def initialize(self):
         """Initialize VBot"""
@@ -203,8 +206,8 @@ class VBot:
                 # Admin commands
                 BotCommand(command="pm", description="Promote user to admin"),
                 BotCommand(command="dm", description="Demote user from admin"),
-                BotCommand(command="tagall", description="Tag all members"),
-                BotCommand(command="cancel", description="Cancel tag operation"),
+                BotCommand(command="t", description="Tag semua anggota secara bertahap"),
+                BotCommand(command="c", description="Hentikan proses tag massal"),
                 BotCommand(command="lock", description="Lock user (auto-delete)"),
                 BotCommand(command="unlock", description="Unlock user"),
                 BotCommand(command="locklist", description="Show locked users"),
@@ -706,10 +709,13 @@ class VBot:
                 await self._handle_locklist_command(message)
 
             # Tag system
-            elif command == '/tagall':
-                await self._handle_tagall_command(message, parts)
-            elif command == '/cancel':
-                await self._handle_cancel_command(message)
+            elif command in self._tag_start_commands:
+                await self._handle_tag_command(message)
+            elif command in self._tag_stop_commands:
+                await self._handle_tag_cancel_command(message)
+            elif command == '/cancel' and not (message.is_group or message.is_channel):
+                # Biarkan generator session dan alur lainnya menangani /cancel di private chat
+                return
 
             # Help command (available to all)
             elif command in ['/help', '#help']:
@@ -891,6 +897,9 @@ By Vzoel Fox's
     def _build_help_pages(self) -> List[Dict[str, object]]:
         """Define help sections for slash commands."""
 
+        tag_start_display = " / ".join(f"`{prefix}t`" for prefix in self._tag_prefixes)
+        tag_stop_display = " / ".join(f"`{prefix}c`" for prefix in self._tag_prefixes)
+
         return [
             {
                 "label": "Music",
@@ -919,8 +928,8 @@ By Vzoel Fox's
                     ("`/lock @user`", "Kunci pengguna agar pesannya dihapus otomatis"),
                     ("`/unlock @user`", "Buka kunci pengguna"),
                     ("`/locklist`", "Daftar pengguna yang terkunci"),
-                    ("`/tagall <text>`", "Mention semua anggota"),
-                    ("`/cancel`", "Batalkan penandaan massal"),
+                    (f"{tag_start_display} [batch] <text>", "Mention semua anggota via edit batch"),
+                    (f"{tag_stop_display}", "Batalkan penandaan massal"),
                 ],
             },
             {
@@ -958,7 +967,7 @@ By Vzoel Fox's
 
         toggle_row: List[Button] = []
         for idx, section in enumerate(self._help_pages):
-            label_prefix = "✅ " if idx == current_index else ""
+            label_prefix = "Aktif | " if idx == current_index else ""
             toggle_row.append(
                 Button.inline(
                     f"{label_prefix}{section['label']}",
@@ -967,9 +976,9 @@ By Vzoel Fox's
             )
 
         navigation_row = [
-            Button.inline("⬅️ Back", f"help:page:{(current_index - 1) % total_pages}".encode()),
+            Button.inline("Sebelumnya", f"help:page:{(current_index - 1) % total_pages}".encode()),
             Button.url("FOUNDER", "https://t.me/VZLfxs"),
-            Button.inline("Next ➡️", f"help:page:{(current_index + 1) % total_pages}".encode()),
+            Button.inline("Berikutnya", f"help:page:{(current_index + 1) % total_pages}".encode()),
         ]
 
         return text, [toggle_row, navigation_row]
@@ -2327,66 +2336,130 @@ Contact @VZLfxs for support & inquiries
             logger.error(f"Error in locklist command: {e}", exc_info=True)
             await message.reply(f"**Error:** {str(e)}")
 
-    async def _handle_tagall_command(self, message, parts):
-        """Handle /tagall command - tag all members"""
+    async def _handle_tag_command(self, message):
+        """Handle perintah tag massal dengan dukungan batch dinamis."""
+        if not config.ENABLE_TAG_SYSTEM:
+            await message.reply(
+                VBotBranding.format_error("Sistem tag sedang dinonaktifkan oleh Vzoel Fox's (Lutpan).")
+            )
+            return
+
         if not message.is_group and not message.is_channel:
-            await message.reply("**Tag all only works in groups!**")
+            await message.reply(
+                VBotBranding.format_error("Perintah tag massal hanya tersedia di grup atau kanal.")
+            )
             return
 
         try:
-            # Get custom message if provided
-            custom_message = "Tagging all members..."
-            if len(parts) > 1:
-                custom_message = ' '.join(parts[1:])
+            reply_message = None
+            if getattr(message, "is_reply", False):
+                try:
+                    reply_message = await message.get_reply_message()
+                except Exception as fetch_error:
+                    logger.debug("Failed to fetch replied message: %s", fetch_error)
 
-            # Start tag all process
+            raw_text = message.raw_text or message.text or ""
+            remainder = ""
+            if raw_text:
+                parts = raw_text.split(maxsplit=1)
+                if len(parts) > 1:
+                    remainder = parts[1].strip()
+
+            provided_batch: Optional[int] = None
+            custom_message = remainder
+
+            if remainder:
+                first_split = remainder.split(maxsplit=1)
+                candidate = first_split[0]
+                rest_text = first_split[1] if len(first_split) > 1 else ""
+                if candidate.isdigit():
+                    provided_batch = int(candidate)
+                    custom_message = rest_text.strip()
+                else:
+                    custom_message = remainder
+
+            if not custom_message and reply_message:
+                reply_text = getattr(reply_message, "raw_text", None) or getattr(reply_message, "message", "")
+                custom_message = reply_text.strip()
+
+            if not custom_message:
+                custom_message = "Sedang menandai seluruh anggota..."
+
+            custom_message = (
+                f"{custom_message}\n\n_Disajikan oleh Vzoel Fox's (Lutpan)_"
+            )
+
+            reply_to_msg_id = getattr(message, "reply_to_msg_id", None)
+
             success = await self.tag_manager.start_tag_all(
                 self.client,
                 message.chat_id,
                 custom_message,
-                message.sender_id
+                message.sender_id,
+                batch_size=provided_batch,
+                reply_to_msg_id=reply_to_msg_id,
             )
 
             if success:
-                await message.reply(
-                    f"**Tag All Started**\n\n"
-                    f"**Message:** {custom_message}\n\n"
-                    f"Tagging all members... Use `/cancel` to stop."
+                confirm_text = (
+                    "**Tag Massal Dimulai**\n\n"
+                    f"**Pesan:** {custom_message}\n\n"
+                    "Bot akan menandai seluruh anggota secara bertahap. Gunakan `.c`/`/c`/`+c` untuk menghentikan."
                 )
-            else:
-                # Check if already tagging
+                await message.reply(
+                    VBotBranding.wrap_message(confirm_text, include_footer=False)
+                )
+                return
+
+            if not success:
                 if message.chat_id in self.tag_manager.active_tags:
                     await message.reply(
-                        "**Tag all already in progress!**\n\n"
-                        "Wait for current process to finish or use `/cancel` to stop it."
+                        VBotBranding.format_error(
+                            "Proses tag massal sedang berlangsung. Tunggu hingga selesai atau gunakan `.c`/`/c`/`+c`."
+                        )
                     )
                 else:
-                    await message.reply("**Error:** Could not start tag all. No members found or insufficient permissions.")
+                    await message.reply(
+                        VBotBranding.format_error(
+                            "Tag massal gagal dimulai. Periksa anggota dan izin bot."
+                        )
+                    )
 
         except Exception as e:
-            logger.error(f"Error in tagall command: {e}", exc_info=True)
-            await message.reply(f"**Error:** {str(e)}")
+            logger.error(f"Error in tag command: {e}", exc_info=True)
+            await message.reply(
+                VBotBranding.format_error(f"Galat sistem: {str(e)}")
+            )
 
-    async def _handle_cancel_command(self, message):
-        """Handle /cancel command - cancel ongoing tag all"""
+    async def _handle_tag_cancel_command(self, message):
+        """Handle perintah pembatalan tag massal."""
         if not message.is_group and not message.is_channel:
-            await message.reply("**Cancel only works in groups!**")
+            await message.reply(
+                VBotBranding.format_error("Perintah pembatalan hanya tersedia di grup atau kanal.")
+            )
             return
 
         try:
             success = await self.tag_manager.cancel_tag_all(message.chat_id)
 
             if success:
+                cancel_text = (
+                    "**Tag Massal Dibatalkan**\n\n"
+                    "Proses penandaan telah dihentikan sesuai permintaan admin."
+                )
                 await message.reply(
-                    "**Tag All Cancelled**\n\n"
-                    "The tagging process has been stopped."
+                    VBotBranding.wrap_message(cancel_text, include_footer=False)
                 )
             else:
-                await message.reply("**No active tag all process in this chat.**")
+                await message.reply(
+                    VBotBranding.format_error("Tidak ada proses tag massal yang aktif di percakapan ini.")
+                )
 
         except Exception as e:
             logger.error(f"Error in cancel command: {e}", exc_info=True)
-            await message.reply(f"**Error:** {str(e)}")
+            await message.reply(
+                VBotBranding.format_error(f"Galat sistem: {str(e)}")
+            )
 
 
 async def main():


### PR DESCRIPTION
## Summary
- update the tag routing to handle `.t`/`/t`/`+t` for batch starts and `.c`/`/c`/`+c` for cancellation while removing the legacy `/tagall`
- refresh permission handling, help output, and runtime messaging so administrators see the new stop instructions
- revise the command documentation to reflect the updated tagging aliases

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e0599b167483249eb7488d56e5ca54