### PR TITLE
Fix admin command handling and help initialization

### DIFF
--- a/core/auth_manager.py
+++ b/core/auth_manager.py
@@ -42,9 +42,6 @@ class AuthManager:
         self._admin_override_commands = (
             self._admin_tag_commands | self._admin_tag_cancel_commands
         )
-        self._admin_override_commands = (
-            self._admin_tag_commands | self._admin_tag_cancel_commands
-        )
         dev_prefix = getattr(config, "PREFIX_DEV", ".") or "."
         self.admin_dot_commands = {f"{dev_prefix}t".lower()}
         self._last_denied_reason: Optional[str] = None
@@ -155,8 +152,7 @@ class AuthManager:
         command = self._normalize_command(message_text)
         if not command:
             return None
-        if command in self._admin_override_commands:
-        if command in self.admin_dot_commands:
+        if command in self._admin_override_commands or command in self.admin_dot_commands:
             return "admin"
         if command.startswith('+'):
             return "owner"
@@ -190,8 +186,7 @@ class AuthManager:
         if command_type == "owner":
             return await self.can_use_owner_command(user_id)
         elif command_type == "admin":
-            if cmd in self._admin_override_commands:
-            if cmd in self.admin_dot_commands:
+            if cmd in self._admin_override_commands or cmd in self.admin_dot_commands:
                 return await self.can_use_admin_command(
                     client,
                     user_id,

--- a/main.py
+++ b/main.py
@@ -103,6 +103,8 @@ class VBot:
         self._tag_prefixes = (".", "/", "+")
         self._tag_start_commands = {f"{prefix}t" for prefix in self._tag_prefixes}
         self._tag_stop_commands = {f"{prefix}c" for prefix in self._tag_prefixes}
+        prefix_dev = getattr(config, "PREFIX_DEV", ".") or "."
+        self._dot_tag_command = (prefix_dev + "t").lower()
         self._help_pages = self._build_help_pages()
         self._music_logo_file_id = getattr(config, "MUSIC_LOGO_FILE_ID", "")
         self._admin_sync_cache: Dict[int, float] = {}
@@ -112,11 +114,6 @@ class VBot:
         self._premium_wrapper_id_limit = 4096
         self._assistant_joined_chats: Set[int] = set()
         self._assistant_join_failed_chats: Set[int] = set()
-        self._tag_prefixes = (".", "/", "+")
-        self._tag_start_commands = {f"{prefix}t" for prefix in self._tag_prefixes}
-        self._tag_stop_commands = {f"{prefix}c" for prefix in self._tag_prefixes}
-        prefix_dev = getattr(config, "PREFIX_DEV", ".") or "."
-        self._dot_tag_command = (prefix_dev + "t").lower()
 
     async def initialize(self):
         """Initialize VBot"""


### PR DESCRIPTION
## Summary
- simplify the admin override command detection in the auth manager to remove the indentation error
- initialize the dot-tag command before building help pages and drop duplicate tag command assignments

## Testing
- python -m compileall .
- python3 main.py *(fails: ConnectionError: Connection to Telegram failed 5 time(s))*

------
https://chatgpt.com/codex/tasks/task_e_68e0a46c96948324bba9ff07555c341d