### PR TITLE
Update tag branding text to {plugins} by VBot

### DIFF
--- a/core/branding.py
+++ b/core/branding.py
@@ -12,8 +12,8 @@ import asyncio
 class VBotBranding:
     """VBot branding and animation utilities"""
 
-    HEADER = "╭━━━━━━━━━━━━━━━━━━━━━━━━━━╮\n│ **VBot Music By Vzoel Fox's** │\n╰━━━━━━━━━━━━━━━━━━━━━━━━━━╯"
-    FOOTER = "╭━━━━━━━━━━━━━━━━━━━━━━━━━━╮\n│ **2025© Vzoel Fox's Lutpan** │\n│      **@VZLfxs**      │\n╰━━━━━━━━━━━━━━━━━━━━━━━━━━╯"
+    HEADER = "**VBot Music – {{plugins}} by VBot**"
+    FOOTER = "**{{plugins}} by VBot**"
 
     # Loading animation frames
     LOADING_FRAMES = [

--- a/main.py
+++ b/main.py
@@ -2383,20 +2383,20 @@ Contact @VZLfxs for support & inquiries
                 elif target.isdigit():
                     target_user_id = int(target)
 
-        if not target_user_id:
-            usage_text = (
-                "**Usage:** `/dm @username` or `/dm <user_id>` or reply to message\n\n"
-                "**Examples:**\n"
-                "• `/dm @user`\n"
-                "• `/dm 123456789`\n"
-                "• Reply to admin message with `/dm`"
-            )
-            await self._reply_with_branding(
-                message,
-                usage_text,
-                include_footer=False,
-            )
-            return
+            if not target_user_id:
+                usage_text = (
+                    "**Usage:** `/dm @username` or `/dm <user_id>` or reply to message\n\n"
+                    "**Examples:**\n"
+                    "• `/dm @user`\n"
+                    "• `/dm 123456789`\n"
+                    "• Reply to admin message with `/dm`"
+                )
+                await self._reply_with_branding(
+                    message,
+                    usage_text,
+                    include_footer=False,
+                )
+                return
 
             # Demote user (remove admin rights)
             from telethon.tl.functions.channels import EditAdminRequest
@@ -2645,20 +2645,20 @@ Contact @VZLfxs for support & inquiries
             if not target_user_id:
                 target_user_id = await self.lock_manager.parse_lock_command(self.client, message)
 
-        if not target_user_id:
-            usage_text = (
-                "**Usage:** `/lock @username` or `/lock <user_id>` or reply to user's message\n\n"
-                "**Examples:**\n"
-                "• `/lock @spammer`\n"
-                "• `/lock 123456789`\n"
-                "• Reply to user message with `/lock`"
-            )
-            await self._reply_with_branding(
-                message,
-                usage_text,
-                include_footer=False,
-            )
-            return
+            if not target_user_id:
+                usage_text = (
+                    "**Usage:** `/lock @username` or `/lock <user_id>` or reply to user's message\n\n"
+                    "**Examples:**\n"
+                    "• `/lock @spammer`\n"
+                    "• `/lock 123456789`\n"
+                    "• Reply to user message with `/lock`"
+                )
+                await self._reply_with_branding(
+                    message,
+                    usage_text,
+                    include_footer=False,
+                )
+                return
 
             # Prevent locking bot developers/owners
             if self.auth_manager.is_developer(target_user_id) or self.auth_manager.is_owner(target_user_id):
@@ -2721,6 +2721,7 @@ Contact @VZLfxs for support & inquiries
                         "**Error:** Protected account detected but failed to apply the automatic lock.",
                         include_footer=False,
                     )
+
                 await self._reply_with_branding(
                     message,
                     "**Error:** You cannot lock bot developers or owners.",
@@ -2796,20 +2797,20 @@ Contact @VZLfxs for support & inquiries
             if not target_user_id:
                 target_user_id = await self.lock_manager.parse_lock_command(self.client, message)
 
-        if not target_user_id:
-            usage_text = (
-                "**Usage:** `/unlock @username` or `/unlock <user_id>` or reply to user's message\n\n"
-                "**Examples:**\n"
-                "• `/unlock @user`\n"
-                "• `/unlock 123456789`\n"
-                "• Reply to user message with `/unlock`"
-            )
-            await self._reply_with_branding(
-                message,
-                usage_text,
-                include_footer=False,
-            )
-            return
+            if not target_user_id:
+                usage_text = (
+                    "**Usage:** `/unlock @username` or `/unlock <user_id>` or reply to user's message\n\n"
+                    "**Examples:**\n"
+                    "• `/unlock @user`\n"
+                    "• `/unlock 123456789`\n"
+                    "• Reply to user message with `/unlock`"
+                )
+                await self._reply_with_branding(
+                    message,
+                    usage_text,
+                    include_footer=False,
+                )
+                return
 
             # Unlock the user
             metadata = self.lock_manager.get_lock_metadata(message.chat_id, target_user_id)
@@ -2958,7 +2959,7 @@ Contact @VZLfxs for support & inquiries
                 custom_message = "Sedang menandai seluruh anggota..."
 
             custom_message = (
-                f"{custom_message}\n\n_Disajikan oleh Vzoel Fox's (Lutpan)_"
+                f"{custom_message}\n\n_{{plugins}} by VBot_"
             )
 
             reply_to_msg_id = getattr(message, "reply_to_msg_id", None)

--- a/modules/tag_manager.py
+++ b/modules/tag_manager.py
@@ -116,7 +116,7 @@ class TagManager:
 
             # Send initial message
             initial_text = (
-                f"{base_message}\n\nSedang memulai proses tag oleh Vzoel Fox's (Lutpan)..."
+                f"{base_message}\n\nSedang memulai proses tag oleh {{plugins}} by VBot..."
             )
             initial_text = f"{base_message}\n\n⏳ Starting tag process..."
             message_obj = await client.send_message(
@@ -154,7 +154,7 @@ class TagManager:
                 progress = f"({session['tagged_count'] + len(batch_members)}/{len(members)})"
                 updated_text = (
                     f"{base_message}\n\n{' '.join(mentions)}\n\n"
-                    f"Progres oleh Vzoel Fox's (Lutpan): {progress}"
+                    f"Progres oleh {{plugins}} by VBot: {progress}"
                 )
 
                 try:
@@ -171,7 +171,7 @@ class TagManager:
 
             # Final message
             final_text = (
-                f"{base_message}\n\nSeluruh {len(members)} anggota berhasil ditandai oleh Vzoel Fox's (Lutpan)."
+                f"{base_message}\n\nSeluruh {len(members)} anggota berhasil ditandai oleh {{plugins}} by VBot."
             )
             try:
                 await message_obj.edit(final_text)
@@ -192,7 +192,7 @@ class TagManager:
             if session and session.get('message_obj'):
                 try:
                     cancel_text = (
-                        f"{session['message']}\n\nProses tag dibatalkan oleh admin Vzoel Fox's (Lutpan)."
+                        f"{session['message']}\n\nProses tag dibatalkan oleh admin {{plugins}} by VBot."
                     )
                     await session['message_obj'].edit(cancel_text)
                 except:


### PR DESCRIPTION
## Summary
- replace Vzoel Fox's (Lutpan) references in tag flow messaging with literal `{plugins} by VBot`
- remove the decorative border from the VBot branding header/footer and align them with the `{plugins} by VBot` label
- update the /t command attribution footer to show `{plugins} by VBot`

## Testing
- python3 -m py_compile main.py modules/tag_manager.py core/branding.py

------
https://chatgpt.com/codex/tasks/task_e_68e0cdb9b3b08324b0e830a334cdfd1c