### PR TITLE
Fix progressive tag branding assembly

### DIFF
--- a/core/branding.py
+++ b/core/branding.py
@@ -17,8 +17,6 @@ class VBotBranding:
     HEADER = "**VBot Music – {plugins} by VBot**"
     FOOTER = "**{plugins} by VBot**"
     DEFAULT_PLUGIN_NAME = "VBot"
-    HEADER = "**VBot Music – {{plugins}} by VBot**"
-    FOOTER = "**{{plugins}} by VBot**"
 
     # Loading animation frames
     LOADING_FRAMES = [

--- a/modules/tag_manager.py
+++ b/modules/tag_manager.py
@@ -121,8 +121,6 @@ class TagManager:
             initial_text = VBotBranding.apply_placeholders(
                 f"{base_message}\n\nSedang memulai proses tag oleh {{plugins}} by VBot...",
                 plugin_name=self.PLUGIN_NAME,
-            initial_text = (
-                f"{base_message}\n\nSedang memulai proses tag oleh {{plugins}} by VBot..."
             )
             message_obj = await client.send_message(
                 chat_id,
@@ -152,16 +150,19 @@ class TagManager:
                             mentions.append(f"@{user.username}")
                         else:
                             mentions.append(f"[User](tg://user?id={user_id})")
-                    except:
+                    except Exception:
                         mentions.append(f"[User](tg://user?id={user_id})")
 
                 # Update message with current batch
                 progress = f"({session['tagged_count'] + len(batch_members)}/{len(members)})"
-                updated_text = VBotBranding.apply_placeholders(
+                progress_text = (
                     f"{base_message}\n\n{' '.join(mentions)}\n\n"
-                    f"Progres oleh {{plugins}} by VBot: {progress}",
-                    plugin_name=self.PLUGIN_NAME,
                     f"Progres oleh {{plugins}} by VBot: {progress}"
+                )
+
+                updated_text = VBotBranding.apply_placeholders(
+                    progress_text,
+                    plugin_name=self.PLUGIN_NAME,
                 )
 
                 try:
@@ -180,12 +181,10 @@ class TagManager:
             final_text = VBotBranding.apply_placeholders(
                 f"{base_message}\n\nSeluruh {len(members)} anggota berhasil ditandai oleh {{plugins}} by VBot.",
                 plugin_name=self.PLUGIN_NAME,
-            final_text = (
-                f"{base_message}\n\nSeluruh {len(members)} anggota berhasil ditandai oleh {{plugins}} by VBot."
             )
             try:
                 await message_obj.edit(final_text)
-            except:
+            except Exception:
                 pass
 
             # Cleanup
@@ -204,11 +203,9 @@ class TagManager:
                     cancel_text = VBotBranding.apply_placeholders(
                         f"{session['message']}\n\nProses tag dibatalkan oleh admin {{plugins}} by VBot.",
                         plugin_name=self.PLUGIN_NAME,
-                    cancel_text = (
-                        f"{session['message']}\n\nProses tag dibatalkan oleh admin {{plugins}} by VBot."
                     )
                     await session['message_obj'].edit(cancel_text)
-                except:
+                except Exception:
                     pass
 
             self._cleanup_tag_session(chat_id)


### PR DESCRIPTION
## Summary
- build the progressive tagging status text before applying branding placeholders
- ensure the updated message uses the plugin placeholder expansion without runtime errors

## Testing
- python3 -m compileall modules/tag_manager.py core/branding.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f2884e2c8324b9daf8dae9cf53b0