### PR TITLE
Add branding asset loader for VBot branding callback

### DIFF
--- a/assets/branding/README.md
+++ b/assets/branding/README.md
@@ -1,0 +1,13 @@
+# VBot Branding Assets
+
+This directory stores visual branding assets that can be shared directly from the bot. Place the official branding image provided by the project owner in this folder using the exact filename `vbot_branding.png`.
+
+The bot will automatically attempt to serve this image when users request branding information. If the image is missing, the bot falls back to a textual notice so chats are never left without a response.
+
+## Adding or Updating the Image
+
+1. Save the branding artwork as `vbot_branding.png`.
+2. Copy the file into this directory: `assets/branding/vbot_branding.png`.
+3. Restart the bot (or redeploy) if necessary so the new asset is available.
+
+The PNG format is recommended to preserve quality and transparency. Ensure the artwork matches the official styling shared with the project.

--- a/core/branding.py
+++ b/core/branding.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-"""
-VBot Branding & Animation Utilities
-Provides consistent branding and loading animations
+"""VBot branding utilities and helpers.
 
-Author: Vzoel Fox's
-Version: 1.0.0
+This module centralises all formatting helpers, placeholder handling, and
+branding asset lookups used throughout the project.
 """
 
 import asyncio
-from typing import Dict, Optional
+from pathlib import Path
+from typing import Dict, Optional, Tuple
 
+from .branding_assets import VBotBrandingAssets
 
 class VBotBranding:
     """VBot branding and animation utilities"""
@@ -17,6 +17,11 @@ class VBotBranding:
     HEADER = "**VBot Music – {plugins} by VBot**"
     FOOTER = "**{plugins} by VBot**"
     DEFAULT_PLUGIN_NAME = "VBot"
+    BRANDING_MISSING_MESSAGE = (
+        "**Branding Asset Tidak Ditemukan**\n\n"
+        "Unggah gambar resmi ke `assets/branding/vbot_branding.png` untuk "
+        "menampilkan branding visual secara otomatis."
+    )
 
     # Loading animation frames
     LOADING_FRAMES = [
@@ -177,3 +182,28 @@ class VBotBranding:
         """Format success message with branding"""
         content = f"**Success**\n\n{success_msg}"
         return VBotBranding.wrap_message(content, include_footer=False)
+
+    # ------------------------------------------------------------------
+    # Branding asset helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def get_branding_media() -> Tuple[Optional[Path], str]:
+        """Return the branding media asset path and a formatted caption."""
+
+        path, caption = VBotBrandingAssets.get_primary_image()
+        formatted_caption = VBotBranding.wrap_message(
+            caption,
+            include_footer=False,
+            plugin_name="Branding",
+        )
+        return path, formatted_caption
+
+    @staticmethod
+    def get_branding_missing_notice() -> str:
+        """Return a formatted notice when the branding asset is absent."""
+
+        return VBotBranding.wrap_message(
+            VBotBranding.BRANDING_MISSING_MESSAGE,
+            include_footer=False,
+            plugin_name="Branding",
+        )

--- a/core/branding_assets.py
+++ b/core/branding_assets.py
@@ -1,0 +1,46 @@
+"""Utility helpers for accessing VBot branding media assets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+_ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets" / "branding"
+
+
+@dataclass(frozen=True)
+class BrandingAsset:
+    """Represents a single branding asset stored on disk."""
+
+    file_name: str
+    caption: str
+
+    @property
+    def path(self) -> Path:
+        """Return the absolute path to the asset on disk."""
+        return _ASSETS_DIR / self.file_name
+
+    def exists(self) -> bool:
+        """Return ``True`` when the asset file exists on disk."""
+        return self.path.exists()
+
+
+class VBotBrandingAssets:
+    """Centralised definitions for branding assets used by the bot."""
+
+    PRIMARY_IMAGE = BrandingAsset(
+        file_name="vbot_branding.png",
+        caption=(
+            "**VBot Official Branding**\n\n"
+            "Representing the signature style of Vzoel Fox's for the VBot project."
+        ),
+    )
+
+    @staticmethod
+    def get_primary_image() -> Tuple[Optional[Path], str]:
+        """Return the primary branding image path and its caption."""
+        asset = VBotBrandingAssets.PRIMARY_IMAGE
+        if asset.exists():
+            return asset.path, asset.caption
+        return None, asset.caption

--- a/main.py
+++ b/main.py
@@ -493,10 +493,17 @@ class VBot:
 
             # Branding info callback
             elif data == "branding:info":
-                await event.answer(
-                    "DEVELOPED by. Vzoel Fox's (Lutpan) ID : @VZLfxs / @itspizolpoks",
-                    alert=True
-                )
+                media_path, caption = VBotBranding.get_branding_media()
+
+                if media_path:
+                    await event.answer("Mengirim branding resmi VBot...")
+                    await event.respond(file=str(media_path), caption=caption)
+                else:
+                    await event.answer(
+                        "Branding image belum tersedia di server bot.",
+                        alert=True,
+                    )
+                    await event.edit(VBotBranding.get_branding_missing_notice())
 
             # Session generator callback
             elif data == "start_gensession":

--- a/modules/tag_manager.py
+++ b/modules/tag_manager.py
@@ -127,9 +127,6 @@ class TagManager:
             # Send initial message
             initial_text = self._format_with_branding(
                 f"{base_message}\n\nSedang memulai proses tag oleh {{plugins}} by VBot..."
-            initial_text = VBotBranding.apply_placeholders(
-                f"{base_message}\n\nSedang memulai proses tag oleh {{plugins}} by VBot...",
-                plugin_name=self.PLUGIN_NAME,
             )
             message_obj = await client.send_message(
                 chat_id,
@@ -167,13 +164,6 @@ class TagManager:
                 progress_text = (
                     f"{base_message}\n\n{' '.join(mentions)}\n\n"
                     f"Progres oleh {{plugins}} by VBot: {progress}"
-                    f"Progres oleh {{plugins}} by VBot: {progress}",
-                    plugin_name=self.PLUGIN_NAME,
-                )
-
-                updated_text = VBotBranding.apply_placeholders(
-                    progress_text,
-                    plugin_name=self.PLUGIN_NAME,
                 )
 
                 updated_text = self._format_with_branding(progress_text)
@@ -193,9 +183,6 @@ class TagManager:
             # Final message
             final_text = self._format_with_branding(
                 f"{base_message}\n\nSeluruh {len(members)} anggota berhasil ditandai oleh {{plugins}} by VBot."
-            final_text = VBotBranding.apply_placeholders(
-                f"{base_message}\n\nSeluruh {len(members)} anggota berhasil ditandai oleh {{plugins}} by VBot.",
-                plugin_name=self.PLUGIN_NAME,
             )
             try:
                 await message_obj.edit(final_text)
@@ -217,9 +204,6 @@ class TagManager:
                 try:
                     cancel_text = self._format_with_branding(
                         f"{session['message']}\n\nProses tag dibatalkan oleh admin {{plugins}} by VBot."
-                    cancel_text = VBotBranding.apply_placeholders(
-                        f"{session['message']}\n\nProses tag dibatalkan oleh admin {{plugins}} by VBot.",
-                        plugin_name=self.PLUGIN_NAME,
                     )
                     await session['message_obj'].edit(cancel_text)
                 except Exception:


### PR DESCRIPTION
## Summary
- add a dedicated branding asset helper module to centralise media metadata
- wire branding utilities and the inline callback to serve the official branding image with a graceful fallback
- document where to place the branding artwork so deployments can include the asset

## Testing
- python -m py_compile core/branding.py core/branding_assets.py main.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f814ef5c83248bc3ca22e8a2dd73