### PR TITLE
Improve music branding visualizer and audio quality controls

### DIFF
--- a/config.py
+++ b/config.py
@@ -171,6 +171,8 @@ MUSIC_ENABLED = _get_bool("MUSIC_ENABLED", True)
 DOWNLOAD_PATH = os.getenv("DOWNLOAD_PATH", "downloads/")
 MAX_FILE_SIZE = int(os.getenv("MAX_FILE_SIZE", str(50 * 1024 * 1024)))  # 50MB
 AUDIO_QUALITY = os.getenv("AUDIO_QUALITY", "bestaudio[ext=m4a]/bestaudio")
+DOWNLOAD_AUDIO_BITRATE = os.getenv("DOWNLOAD_AUDIO_BITRATE", "8000")
+STREAM_AUDIO_QUALITY = os.getenv("STREAM_AUDIO_QUALITY", "8k")
 MUSIC_LOGO_FILE_ID = os.getenv("MUSIC_LOGO_FILE_ID", "6269447591602883849")
 
 # ==============================================


### PR DESCRIPTION
## Summary
- add configuration toggles for download bitrate and streaming audio quality with 8k defaults
- adjust the music manager to respect the new bitrate and audio quality preferences
- enhance the now playing reply by sending the configured logo with fallbacks and an ASCII visualizer

## Testing
- python -m compileall main.py core/music_manager.py config.py

------
https://chatgpt.com/codex/tasks/task_e_68e104ccc24483248cc3bedd373bde60