### PR TITLE
Handle music logo fallbacks without bundled binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ ENABLE_PRIVACY_SYSTEM=true
 # Tag system tuning
 TAG_BATCH_SIZE=5
 TAG_DELAY=2.0
+
+# Music branding
+# Provide either a Telegram file ID or a local/HTTP path to an existing image.
+# Binary logo assets are not bundled with the project, so point this to your own file if desired.
+MUSIC_LOGO_FILE_ID=
+MUSIC_LOGO_FILE_PATH=
 ```
 
 ## Commands 📝

--- a/assets/branding/README.md
+++ b/assets/branding/README.md
@@ -2,6 +2,8 @@
 
 This directory stores visual branding assets that can be shared directly from the bot. Place the official branding image provided by the project owner in this folder using the exact filename `vbot_branding.png`.
 
+For music playback you can optionally provide a separate logo image. The bot reads the `MUSIC_LOGO_FILE_PATH` environment variable and, when set to a valid file or HTTP URL, sends that artwork with queue updates. Ship your own `music_logo.jpg` (or any filename you prefer) and update the configuration path accordingly.
+
 The bot will automatically attempt to serve this image when users request branding information. If the image is missing, the bot falls back to a textual notice so chats are never left without a response.
 
 ## Adding or Updating the Image

--- a/config.py
+++ b/config.py
@@ -173,7 +173,14 @@ MAX_FILE_SIZE = int(os.getenv("MAX_FILE_SIZE", str(50 * 1024 * 1024)))  # 50MB
 AUDIO_QUALITY = os.getenv("AUDIO_QUALITY", "bestaudio[ext=m4a]/bestaudio")
 DOWNLOAD_AUDIO_BITRATE = os.getenv("DOWNLOAD_AUDIO_BITRATE", "8000")
 STREAM_AUDIO_QUALITY = os.getenv("STREAM_AUDIO_QUALITY", "8k")
-MUSIC_LOGO_FILE_ID = os.getenv("MUSIC_LOGO_FILE_ID", "6269447591602883849")
+_default_music_logo_path = (_current_dir / "assets" / "branding" / "music_logo.jpg").resolve()
+if _default_music_logo_path.is_file():
+    _default_music_logo_path_value = str(_default_music_logo_path)
+else:
+    _default_music_logo_path_value = ""
+
+MUSIC_LOGO_FILE_ID = os.getenv("MUSIC_LOGO_FILE_ID", "")
+MUSIC_LOGO_FILE_PATH = os.getenv("MUSIC_LOGO_FILE_PATH", _default_music_logo_path_value)
 
 # ==============================================
 # ASSISTANT ACCOUNT (Voice Chat Streaming)

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ from telethon.tl.types import BotCommand, BotCommandScopeDefault
 from telethon.utils import pack_bot_file_id
 from telethon.errors import (
     ChatAdminRequiredError,
+    MessageNotModifiedError,
     UserAlreadyParticipantError,
     UserPrivacyRestrictedError,
     UserNotMutualContactError,
@@ -1607,8 +1608,8 @@ Contact @VZLfxs for support & inquiries
             send_kwargs["buttons"] = buttons
 
         logo_id = self._music_logo_file_id or getattr(config, "MUSIC_LOGO_FILE_ID", "")
-        try:
-            if logo_id:
+        if logo_id:
+            try:
                 await self.client.send_file(chat_id, logo_id, **send_kwargs)
                 if status_message:
                     try:
@@ -1616,13 +1617,15 @@ Contact @VZLfxs for support & inquiries
                     except Exception:
                         pass
                 return True
-        except Exception as exc:
-            logger.error(f"Failed to send configured music logo: {exc}")
+            except Exception as exc:
+                logger.error(f"Failed to send configured music logo: {exc}")
 
-        fallback_path = Path("assets/branding/vbot_branding.png")
-        if fallback_path.exists():
+        logo_path_value = getattr(config, "MUSIC_LOGO_FILE_PATH", "")
+        logo_path = Path(logo_path_value).expanduser() if logo_path_value else None
+
+        async def _send_fallback(source: str) -> bool:
             try:
-                await self.client.send_file(chat_id, fallback_path, **send_kwargs)
+                await self.client.send_file(chat_id, source, **send_kwargs)
                 if status_message:
                     try:
                         await status_message.delete()
@@ -1630,13 +1633,21 @@ Contact @VZLfxs for support & inquiries
                         pass
                 return True
             except Exception as exc:
-                logger.error(f"Failed to send fallback branding image: {exc}")
+                logger.error(f"Failed to send fallback music logo from '{source}': {exc}")
+                return False
 
-        if status_message:
-            try:
-                await status_message.edit(caption, buttons=buttons)
-            except Exception as exc:
-                logger.error(f"Unable to update status message with caption fallback: {exc}")
+        if logo_path_value:
+            if logo_path_value.startswith(("http://", "https://")):
+                if await _send_fallback(logo_path_value):
+                    return True
+            elif logo_path and logo_path.is_file():
+                if await _send_fallback(str(logo_path)):
+                    return True
+            else:
+                logger.error(
+                    "Configured music logo fallback path '%s' does not exist",
+                    logo_path_value,
+                )
 
         return False
 
@@ -1925,7 +1936,15 @@ Contact @VZLfxs for support & inquiries
                     status_message=status_msg,
                 )
                 if not sent:
-                    await status_msg.edit(caption, buttons=buttons_param)
+                    try:
+                        await status_msg.edit(caption, buttons=buttons_param)
+                    except MessageNotModifiedError:
+                        logger.debug("Music status message was already up to date")
+                    except Exception as exc:
+                        logger.error(
+                            "Unable to update status message with caption fallback: %s",
+                            exc,
+                        )
 
                 return
 


### PR DESCRIPTION
## Summary
- remove the bundled music logo binary and document that operators should provide their own asset
- make the music logo fallback accept local file paths or HTTP URLs and handle missing files gracefully
- avoid MessageNotModified errors when updating the music status message during fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e108c7071483249bdb931fb2563d14