### PR TITLE
Ensure commands are logged only once

### DIFF
--- a/main.py
+++ b/main.py
@@ -573,6 +573,9 @@ class VBot:
             self._command_context[message_id] = CommandStatus(start_time=start_time)
         command_text = message.text.lower()
 
+        command_success = False
+        error_message: Optional[str] = None
+
         try:
             command_parts = command_text.split()
             command = command_parts[0]
@@ -599,16 +602,7 @@ class VBot:
 
             if not has_permission:
                 error_msg = self.auth_manager.get_permission_error_message(command_type)
-
-                # Log failed permission check
-                execution_time = (datetime.now() - start_time).total_seconds()
-                await vbot_logger.log_command(
-                    message.sender_id,
-                    command_text,
-                    success=False,
-                    execution_time=execution_time,
-                    error="Permission denied"
-                )
+                error_message = "Permission denied"
 
                 if config.ENABLE_PRIVACY_SYSTEM:
                     await self.privacy_manager.process_private_command(
@@ -648,32 +642,17 @@ class VBot:
 
             # Route commands
             await self._route_command(message, command, command_parts)
-
-            # Log successful command execution
-            execution_time = (datetime.now() - start_time).total_seconds()
-            await vbot_logger.log_command(
-                message.sender_id,
-                command_text,
-                success=True,
-                execution_time=execution_time
-            )
+            command_success = True
 
         except Exception as e:
             # Log error with full context
-            execution_time = (datetime.now() - start_time).total_seconds()
+            if error_message is None:
+                error_message = str(e)
             await vbot_logger.log_error(
                 e,
                 context=f"Command execution: {command_text}",
                 user_id=message.sender_id,
                 send_to_telegram=True
-            )
-
-            await vbot_logger.log_command(
-                message.sender_id,
-                command_text,
-                success=False,
-                execution_time=execution_time,
-                error=str(e)
             )
 
             command_status = self._command_context.get(message_id) if message_id is not None else None
@@ -687,6 +666,14 @@ class VBot:
                     logger.debug(f"Failed to update status message: {edit_error}")
 
         finally:
+            execution_time = (datetime.now() - start_time).total_seconds()
+            await vbot_logger.log_command(
+                message.sender_id,
+                command_text,
+                success=command_success,
+                execution_time=execution_time,
+                error=error_message,
+            )
             self._finalize_command_status(message_id)
 
     def _finalize_command_status(self, message_id: Optional[int]):


### PR DESCRIPTION
## Summary
- centralize `_handle_command` logging so each command writes a single log entry
- track success and error state to keep permission failures and exceptions reported accurately

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e149c8bc248324aa7dd9e2a60e2ddc